### PR TITLE
fix test failure

### DIFF
--- a/conduit/test/test_modelresource_conduit_formats.py
+++ b/conduit/test/test_modelresource_conduit_formats.py
@@ -61,7 +61,7 @@ class ResourceFormatTestCase(ConduitTestCase):
 
         # override urls
         self.original_urls = example.urls.urlpatterns
-        example.urls.urlpatterns += patterns(
+        example.urls.urlpatterns = patterns(
             '',
             url(r'^api_as_func/', include(self.resource_as_func.Meta.api.urls)),
             url(r'^api_as_mixin/', include(self.resource_as_mixin.Meta.api.urls)),


### PR DESCRIPTION
A test was failing because a test in `test_modelresource_conduit_formats` was appending to the default urls patterns instead of overriding them. [The intention of the test was to temporarily assign new url patterns while running and then reassign the original url patterns.](https://github.com/akoumjian/django-conduit/blob/master/conduit/test/test_modelresource_conduit_formats.py#L73)

```
FAIL: test_add_resource_uri (conduit.test.test_modelresource_methods.MethodTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/bturner/Projects/django-conduit/conduit/test/test_modelresource_methods.py", line 362, in test_add_resource_uri
    self.assertEqual(data['resource_uri'], '/api/{0}/bar/{1}/'.format(self.resource.Meta.api.name, bar.pk))
AssertionError: '/api_as_context/v1/bar/1/' != '/api/v1/bar/1/'
```
