### PR TITLE
Fix GFK resource response when embed is True

### DIFF
--- a/conduit/api/fields.py
+++ b/conduit/api/fields.py
@@ -392,8 +392,9 @@ class GenericForeignKeyField(APIField):
         return resource
 
     def dehydrate(self, request, parent_inst, bundle=None):
-        obj = bundle['obj']
-        self.setup_resource(obj=obj, api=parent_inst.Meta.api)
+        # obj = bundle['obj']
+        obj = getattr(bundle['obj'], self.attribute)
+        self.setup_resource(obj=bundle['obj'], api=parent_inst.Meta.api)
         resource = self.resource_cls()
         resource.Meta.api = parent_inst.Meta.api
 

--- a/conduit/test/test_resources.py
+++ b/conduit/test/test_resources.py
@@ -87,7 +87,7 @@ class ResourceTestCase(ConduitTestCase):
 
         bar_resource = content['objects'][0]
         self.assertEqual(bar_resource['object_id'], bar.id)
-        self.assertEqual(bar_resource['content_type_id'], ctype.id)
+        self.assertEqual(bar_resource['content_type'], ctype.id)
 
         self.assertIsInstance(bar_resource['content_object'], dict)
         self.assertEqual(bar_resource['content_object']['id'], bar.id)

--- a/conduit/test/test_resources.py
+++ b/conduit/test/test_resources.py
@@ -81,7 +81,7 @@ class ResourceTestCase(ConduitTestCase):
         bar = Bar.objects.get(name='Bar name one')
         ctype = ContentType.objects.get(name='bar')
         response = self.client.get(item_uri)
-        content = json.loads(response.content)
+        content = json.loads(response.content.decode())
 
         self.assertEqual(content['meta']['total'], 1)
 


### PR DESCRIPTION
When `embed=True` is set on a GFK field, the api response includes the parent resource in the gfk field *again* instead of embedding the related resource:

    {
        "content_type_id": 8,
        "object_id": 1,
        "content_object": {
            "object_id": 1,
            "resource_uri": "/api/v1/bar/1/",
            "content_type_id": 8,
            "content_type": 8,
            "id": 1},
        "content_type": 8,
        "id": 1,
        "resource_uri": "/api/v1/item/1/"
    }

The response should embed the related resource like this:

    {
        "content_type_id": 8,
        "object_id": 1,
        "content_object": {
            "id": 1,
            "name": "Foo"
            "resource_uri": "/api/v1/bar/1/"
        },
        "content_type": 8,
        "id": 1,
        "resource_uri": "/api/v1/item/1/"
    }