### PR TITLE
Allow submitting empty data for fks that are not required

### DIFF
--- a/conduit/test/test_resources.py
+++ b/conduit/test/test_resources.py
@@ -266,3 +266,23 @@ class ResourceTestCase(ConduitTestCase):
         self.assertEqual(content['integer'], 12)
         self.assertEqual(content['name'], 'Foo Name')
         self.assertEqual(content['text'], 'text goes here')
+
+    def test_null_fk(self):
+        data = {
+            'bazzes': {},
+            'boolean': False,
+            'decimal': '110.12',
+            'float_field': 100000.123456789,
+            'integer': 12,
+            'name': 'Foo Name',
+            'text': 'text goes here'
+        }
+        resource_uri = self.foo_resource._get_resource_uri()
+        response = self.client.post(
+            resource_uri,
+            json.dumps(data),
+            content_type='application/json'
+        )
+        content = json.loads(response.content.decode())
+
+        self.assertEqual(content['bar'], {})


### PR DESCRIPTION
If you have a FK field that is not required and you don't submit that field in your data, you get a `KeyError` when Conduit tries to save the related object.

A request to a Conduit endpoint with an empty object for a FK creates an object with empty attributes and adds a `resource_uri` attribute that points to the list endpoint for the resource:

    {
        'id': 1,
        'name': '',
        'resource_uri': '/api/v1/bar/'
    }

This change prevents creating a FK if no data is submitted in the request. If you omit data for a non-required FK field in your request data, then the response will return an empty object in the response:

    {
        ...
       'bar': {},
       ...
    }
