### PR TITLE
django 1.7 requires default value for BooleanFields

### DIFF
--- a/example/example/models.py
+++ b/example/example/models.py
@@ -15,7 +15,7 @@ class Foo(models.Model):
     text = models.TextField()
     integer = models.IntegerField()
     float_field = models.FloatField()
-    boolean = models.BooleanField()
+    boolean = models.BooleanField(default=False)
     created = models.DateTimeField(auto_now_add=True)
     birthday = models.DateField(auto_now_add=True)
     decimal = models.DecimalField(max_digits=5, decimal_places=2)


### PR DESCRIPTION
Running tests with Django 1.7 reports this warning:

    example.Foo.boolean: (1_6.W002) BooleanField does not have a default value.
        HINT: Django 1.6 changed the default value of BooleanField from False to None. See https://docs.djangoproject.com/en/1.6/ref/models/fields/#booleanfield for more information.

Setting a default value on the BooleanField silences it.