### PR TITLE
Adds hooks for from_basic_type and to_basic_type for use in Custom APIFields

### DIFF
--- a/conduit/api/base.py
+++ b/conduit/api/base.py
@@ -430,6 +430,16 @@ class ModelResource(Resource):
         """
         Convert deserialized data types into Python types
         """
+        explicit_field = self._get_explicit_field_by_attribute(
+            attribute=field.name
+        )
+
+        if explicit_field:
+            try:
+                return explicit_field.from_basic_type(data)
+            except AttributeError:
+                pass
+
         if isinstance(field, models.AutoField):
             return data
 
@@ -832,6 +842,15 @@ class ModelResource(Resource):
         """
         Convert complex data types into serializable types
         """
+        explicit_field = self._get_explicit_field_by_attribute(
+            attribute=field.name)
+
+        if explicit_field:
+            try:
+                return explicit_field.to_basic_type(obj, field)
+            except AttributeError as err:
+                pass
+
         if isinstance(field, models.AutoField):
             return field.value_from_object(obj)
 

--- a/conduit/test/test_resources.py
+++ b/conduit/test/test_resources.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from django.contrib.contenttypes.models import ContentType
 
-from conduit.api import Api
+from conduit.api import Api, fields
 from conduit.test.testcases import ConduitTestCase
 
 from api.views import BarResource, ContentTypeResource, FooResource, ItemResource
@@ -248,7 +248,8 @@ class ResourceTestCase(ConduitTestCase):
             'id': 1,
             'integer': 12,
             'name': 'Foo Name',
-            'text': 'text goes here'
+            'text': 'text goes here',
+            'custom_field': 'some custom text',
         }
 
         foo_list_uri = self.foo_resource._get_resource_uri()
@@ -298,3 +299,4 @@ class ResourceTestCase(ConduitTestCase):
         self.assertEqual(content['integer'], 12)
         self.assertEqual(content['name'], 'Foo Name')
         self.assertEqual(content['text'], 'text goes here')
+        self.assertEqual(content['custom_field'], 'some custom text')

--- a/example/api/views.py
+++ b/example/api/views.py
@@ -1,9 +1,23 @@
 ## api/views.py
 from django.contrib.contenttypes.models import ContentType
 
-from conduit.api import ModelResource
+from conduit.api import ModelResource, fields
 from conduit.api.fields import ForeignKeyField, ManyToManyField, GenericForeignKeyField
 from example.models import Bar, Baz, Foo, Item
+
+
+class CustomField(fields.APIField):
+    def __init__(self, attribute=None):
+        self.attribute = attribute
+
+    def from_basic_type(self, data):
+        return data
+
+    def to_basic_type(self, obj, field):
+        return field.value_from_object(obj)
+
+    def dehydrate(self, request, parent_inst, bundle=None):
+        return bundle
 
 
 class BarResource(ModelResource):
@@ -39,6 +53,7 @@ class FooResource(ModelResource):
             resource_cls=BazResource,
             embed=True
         )
+        custom_field = CustomField(attribute='custom_field')
 
 
 class ItemResource(ModelResource):

--- a/example/example/models.py
+++ b/example/example/models.py
@@ -2,6 +2,15 @@ from django.contrib.contenttypes import generic
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 
+
+class CustomField(models.Field):
+    def __init__(self, *args, **kwargs):
+        super(CustomField, self).__init__(*args, **kwargs)
+
+    def db_type(self, connection):
+        return 'customfield'
+
+
 class Bar(models.Model):
     name = models.CharField(max_length=250)
 
@@ -22,6 +31,7 @@ class Foo(models.Model):
     file_field = models.FileField(upload_to='test')
     bar = models.ForeignKey(Bar, null=True)
     bazzes = models.ManyToManyField(Baz)
+    custom_field = CustomField()
 
 
 class Item(models.Model):


### PR DESCRIPTION
I'm using `django-taggit`in one of the models I'm using for a conduit api. A problem I encountered was being able to hook into from_basic_type and to_basic_type from my `fields.APIField` subclass in order to return values when my subclass is processed by conduit.

I think this solution warrants some discussion as far as the approach I've taken, we might be able to cleanup the api around `APIField` subclasses, but I like that in general this means you can define a custom field for use in an API without having to make changes to conduit itself.